### PR TITLE
feat(package) Command package:download

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -8,6 +8,7 @@ use Continuous\Cli\Command\Build\BuildStopCommand;
 use Continuous\Cli\Command\Company\CompanyListCommand;
 use Continuous\Cli\Command\ConfigureCommand;
 use Continuous\Cli\Command\Pipeline\PipelineExportCommand;
+use Continuous\Cli\Command\Package\PackageDownloadCommand;
 use Continuous\Cli\Command\Project\ProjectListCommand;
 use Continuous\Cli\Command\Repository\RepositoryListCommand;
 use Symfony\Component\Console\Application;
@@ -36,6 +37,7 @@ final class ApplicationFactory
         $application->add(new BuildStartCommand());
         $application->add(new BuildStopCommand());
         $application->add(new PipelineExportCommand());
+        $application->add(new PackageDownloadCommand());
 
         return $application;
     }

--- a/src/Command/Build/BuildListCommand.php
+++ b/src/Command/Build/BuildListCommand.php
@@ -35,7 +35,7 @@ class BuildListCommand extends CommandAbstract
                 's',
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'the build status',
-                Build::STATE
+                Build::STATES
             )
             ->addOption(
                 'noPr',

--- a/src/Command/Package/PackageDownloadCommand.php
+++ b/src/Command/Package/PackageDownloadCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Continuous\Cli\Command\Package;
+
+use Continuous\Cli\Command\CommandAbstract;
+use Continuous\Sdk\Collection;
+use Continuous\Sdk\Entity\Build;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PackageDownloadCommand extends CommandAbstract
+{
+    const PACKAGE_TYPES = ['deploy', 'test'];
+
+    protected function configure()
+    {
+        $this
+            ->setName('package:download')
+            ->setDescription('Download package of continuousphp build.')
+            ->setHelp('This command download package for latest build of pipeline the one you specify by build ID.')
+            ->addArgument('provider', InputArgument::REQUIRED, 'The repository provider')
+            ->addArgument('repository', InputArgument::REQUIRED, 'The repository name')
+            ->addArgument('destination', InputArgument::OPTIONAL, 'The destination path of package file, by default current workdir')
+        ;
+
+        $this
+            ->addOption(
+                'ref',
+                'r',
+                InputOption::VALUE_OPTIONAL,
+                'The git reference'
+            )
+            ->addOption(
+                'id',
+                'i',
+                InputOption::VALUE_OPTIONAL,
+                'The build ID'
+            )
+            ->addOption(
+                'type',
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'The package type (deploy|test)',
+                'deploy'
+            )
+            ->addOption(
+                'pr',
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'The Pull Request ID'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     * @throws \Continuous\Sdk\Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        parent::execute($input, $output);
+
+        $packageType = $input->getOption('type');
+        $buildId = $input->getOption('id');
+        $destination = getcwd() . '/' . $input->getArgument('destination');
+
+        if (false === file_exists($destination)) {
+            return $output->writeln(
+                "<error>ERROR : directory $destination not exist</error>"
+            );
+        }
+
+        if (!$buildId && $latestBuild = $this->findLastBuildId($input, $output)) {
+            $buildId = $latestBuild->get('buildId');
+        }
+
+        if (false === in_array($packageType, static::PACKAGE_TYPES)) {
+            return $output->writeln(
+                "<error>ERROR : package type option must be <b>deploy</b> or <b>test</b> only</error>"
+            );
+        }
+
+        if (!$buildId) {
+            return $output->writeln(
+                "<error>ERROR : no build ID has been found</error>"
+            );
+        }
+
+        $package = $this->continuousClient->downloadPackage([
+            'provider' => static::mapProviderToSdk($input->getArgument('provider')),
+            'repository' => $input->getArgument('repository'),
+            'buildId' => $buildId,
+            'packageType' => $packageType,
+            'destination' => getcwd() . '/' . $input->getArgument('destination')
+        ]);
+
+        $output->writeln('Package downloaded at ' . $package['path']);
+    }
+
+    /**
+     * Find the latest build of repository
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return mixed|null
+     */
+    private function findLastBuildId(InputInterface $input, OutputInterface $output): ?Build
+    {
+        $pr = $input->getOption('pr');
+        $filters = [
+            'provider' => static::mapProviderToSdk($input->getArgument('provider')),
+            'repository' => $input->getArgument('repository'),
+            'result' => ['success', 'warning'],
+            'state' => ['complete'],
+            'exclude_pull_requests' => !$pr ? 1 : 0,
+            'page_size' => 1,
+        ];
+
+        if ($input->hasOption('ref')) {
+            $filters['pipeline_id'] = $input->getOption('ref');
+        }
+
+        if ($pr) {
+            $filters['pull_request_id'] = (int)$pr;
+        }
+
+        /** @var Collection $builds $builds */
+        $builds = $this->continuousClient->getBuilds($filters);
+
+        return 0 === $builds->count() ? null : $builds->getIterator()->current();
+    }
+}


### PR DESCRIPTION
Add the command package to be able to download build package deploy or test

```bash
➜  cli git:(feat/package) ✗ ./bin/continuousphp package:download --help                                 Usage:
  package:download [options] [--] <provider> <repository> [<destination>]

Arguments:                
  provider                 The repository provider  
  repository               The repository name      
  destination              The destination path of package file, by default current workdir

Options:                  
  -r, --ref[=REF]          The git reference        
  -i, --id[=ID]            The build ID             
  -t, --type[=TYPE]        The package type (deploy|test) [default: "deploy"]
  -p, --pr[=PR]            The Pull Request ID      
      --token[=TOKEN]      The token of the continuousphp user                                           
      --profile[=PROFILE]  The profile of the configured credentials. See route configure
  -h, --help               Display this help message                                                     
  -q, --quiet              Do not output any message                                                     
  -V, --version            Display this application version                                              
      --ansi               Force ANSI output        
      --no-ansi            Disable ANSI output      
  -n, --no-interaction     Do not ask any interactive question                                           
  -v|vv|vvv, --verbose     Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:                     
  This command download package for latest build of pipeline the one you specify by build ID.

```